### PR TITLE
[FIX] Change from Permit To NotEOA (flash loan validation)

### DIFF
--- a/contracts/nft/Booster.sol
+++ b/contracts/nft/Booster.sol
@@ -141,6 +141,12 @@ contract Booster is
     _;
   }
 
+  /// @dev Require that the caller must be an EOA account to avoid flash loans.
+  modifier onlyEOA() {
+    require(msg.sender == tx.origin, "Booster::onlyEOA:: not eoa");
+    _;
+  }
+
   /**
    * @notice Triggers stopped state
    * @dev Only possible when contract not paused.
@@ -193,15 +199,14 @@ contract Booster is
   function stakeNFT(
     address _stakeToken,
     address _nftAddress,
-    uint256 _nftTokenId,
-    bytes calldata _sig
+    uint256 _nftTokenId
   )
     external
     whenNotPaused
     isStakeTokenOK(_stakeToken)
     isBoosterNftOK(_stakeToken, _nftAddress, _nftTokenId)
     nonReentrant
-    permit(_sig)
+    onlyEOA
   {
     _stakeNFT(_stakeToken, _nftAddress, _nftTokenId);
   }
@@ -232,13 +237,7 @@ contract Booster is
   /// @notice function for unstaking a current nft
   /// @dev This one is a preparation for nft staking info, if nft address and nft token id are the same with existing record, it will be reverted
   /// @param _stakeToken a specified stake token address
-  function unstakeNFT(address _stakeToken, bytes calldata _sig)
-    external
-    whenNotPaused
-    isStakeTokenOK(_stakeToken)
-    nonReentrant
-    permit(_sig)
-  {
+  function unstakeNFT(address _stakeToken) external whenNotPaused isStakeTokenOK(_stakeToken) nonReentrant onlyEOA {
     _unstakeNFT(_stakeToken);
   }
 

--- a/contracts/nft/LatteMarket.sol
+++ b/contracts/nft/LatteMarket.sol
@@ -149,6 +149,12 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
     _;
   }
 
+  /// @dev Require that the caller must be an EOA account to avoid flash loans.
+  modifier onlyEOA() {
+    require(msg.sender == tx.origin, "LatteMarket::onlyEOA:: not eoa");
+    _;
+  }
+
   modifier onlyBiddingNFT(address _nftAddress, uint256 _categoryId) {
     require(
       latteNFTMetadata[_nftAddress][_categoryId].isBidding,
@@ -197,19 +203,14 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
   /// @notice buyNFT based on its category id
   /// @param _nftAddress - nft address
   /// @param _categoryId - category id for each nft address
-  /// @param _sig - signed signature using message sign
-  function buyNFT(
-    address _nftAddress,
-    uint256 _categoryId,
-    bytes calldata _sig
-  )
+  function buyNFT(address _nftAddress, uint256 _categoryId)
     external
     payable
     whenNotPaused
     onlySupportedNFT(_nftAddress)
     withinBlockRange(_nftAddress, _categoryId)
     onlyNonBiddingNFT(_nftAddress, _categoryId)
-    permit(_sig)
+    onlyEOA
   {
     _buyNFTTo(_nftAddress, _categoryId, _msgSender(), 1);
   }
@@ -218,20 +219,11 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
   /// @param _nftAddress - nft address
   /// @param _categoryId - category id for each nft address
   /// @param _size - amount to buy
-  /// @param _sig - signed signature using message sign
   function buyBatchNFT(
     address _nftAddress,
     uint256 _categoryId,
-    uint256 _size,
-    bytes calldata _sig
-  )
-    external
-    payable
-    whenNotPaused
-    onlySupportedNFT(_nftAddress)
-    onlyNonBiddingNFT(_nftAddress, _categoryId)
-    permit(_sig)
-  {
+    uint256 _size
+  ) external payable whenNotPaused onlySupportedNFT(_nftAddress) onlyNonBiddingNFT(_nftAddress, _categoryId) onlyEOA {
     LatteNFTMetadata memory metadata = latteNFTMetadata[_nftAddress][_categoryId];
     /// re-use a storage usage by using the same metadata to validate
     /// multiple modifiers can cause stack too deep exception
@@ -259,12 +251,10 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
   /// @param _nftAddress - nft address
   /// @param _categoryId - category id for each nft address
   /// @param _to whom this will be bought to
-  /// @param _sig - signed signature using message sign
   function buyNFTTo(
     address _nftAddress,
     uint256 _categoryId,
-    address _to,
-    bytes calldata _sig
+    address _to
   )
     external
     payable
@@ -272,7 +262,7 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
     onlySupportedNFT(_nftAddress)
     withinBlockRange(_nftAddress, _categoryId)
     onlyNonBiddingNFT(_nftAddress, _categoryId)
-    permit(_sig)
+    onlyEOA
   {
     _buyNFTTo(_nftAddress, _categoryId, _to, 1);
   }
@@ -498,12 +488,10 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
   /// @param _nftAddress - nft address
   /// @param _categoryId - category id
   /// @param _price - bidding price
-  /// @param _sig - signature
   function bidNFT(
     address _nftAddress,
     uint256 _categoryId,
-    uint256 _price,
-    bytes calldata _sig
+    uint256 _price
   )
     external
     payable
@@ -511,7 +499,7 @@ contract LatteMarket is ERC721HolderUpgradeable, OwnableUpgradeable, PausableUpg
     onlySupportedNFT(_nftAddress)
     withinBlockRange(_nftAddress, _categoryId)
     onlyBiddingNFT(_nftAddress, _categoryId)
-    permit(_sig)
+    onlyEOA
   {
     _bidNFT(_nftAddress, _categoryId, _price);
   }

--- a/contracts/nft/OGNFTOffering.sol
+++ b/contracts/nft/OGNFTOffering.sol
@@ -139,6 +139,12 @@ contract OGNFTOffering is ERC721HolderUpgradeable, OwnableUpgradeable, PausableU
     _;
   }
 
+  /// @dev Require that the caller must be an EOA account to avoid flash loans.
+  modifier onlyEOA() {
+    require(msg.sender == tx.origin, "OGNFTOffering::onlyEOA:: not eoa");
+    _;
+  }
+
   /// @notice set price model for getting a price
   function setPriceModel(IOGPriceModel _priceModel) external onlyOwner {
     require(address(_priceModel) != address(0), "OGNFTOffering::permit::price model cannot be address(0)");
@@ -194,14 +200,7 @@ contract OGNFTOffering is ERC721HolderUpgradeable, OwnableUpgradeable, PausableU
 
   /// @notice buyNFT based on its category id
   /// @param _categoryId - category id for each nft address
-  /// @param _sig - signed signature using message sign
-  function buyNFT(uint256 _categoryId, bytes calldata _sig)
-    external
-    payable
-    whenNotPaused
-    withinBlockRange(_categoryId)
-    permit(_sig)
-  {
+  function buyNFT(uint256 _categoryId) external payable whenNotPaused withinBlockRange(_categoryId) onlyEOA {
     _buyNFTTo(_categoryId, _msgSender());
   }
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "script:mainnet:nft:011": "hardhat --network mainnet run --no-compile ./scripts/nft/og_nft_change_base_uri.ts",
     "script:mainnet:nft:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/nft/timelock/timelock_set_stake_token_to_be_boosted.ts",
     "script:mainnet:nft:timelock:001": "hardhat --network mainnet run --no-compile ./scripts/nft/timelock/timelock_booster_config_set_stake_token_category_allowance.ts",
+    "script:mainnet:nft:timelock:002": "hardhat --network mainnet run --no-compile ./scripts/nft/timelock/upgrade_booster.ts",
     "script:mainnet:nft:upgrade:000": "hardhat --network mainnet run --no-compile ./scripts/nft/upgrade/upgrade_booster.ts",
     "script:mainnet:nft:upgrade:001": "hardhat --network mainnet run --no-compile ./scripts/nft/upgrade/upgrade_booster_config.ts",
     "script:mainnet:nft:upgrade:002": "hardhat --network mainnet run --no-compile ./scripts/nft/upgrade/upgrade_latte_nft.ts",
@@ -85,11 +86,13 @@
     "script:mainnet:market:upgrade:000": "hardhat --network mainnet run --no-compile ./scripts/market/upgrade/upgrade_latte_market.ts",
     "script:mainnet:market:validate:000": "hardhat --network mainnet run --no-compile ./scripts/market/validate/deploy_latte_market.ts",
     "script:mainnet:market:validate:001": "hardhat --network mainnet run --no-compile ./scripts/market/validate/ready_to_sell.ts",
+    "script:mainnet:market:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/market/timelock/upgrade.ts",
 
     "script:mainnet:ogNftOffering:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/ready_to_sell.ts",
     "script:mainnet:ogNftOffering:upgrade:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/upgrade/upgrade_og_nft_offering.ts",
     "script:mainnet:ogNftOffering:validate:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/validate/deploy_og_nft_offering.ts",
     "script:mainnet:ogNftOffering:validate:001": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/validate/ready_to_sell.ts",
+    "script:mainnet:ogNftOffering:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/timelock/upgrade.ts",
     
     "script:mainnet:periphery:T000": "hardhat --network mainnet run --no-compile ./scripts/periphery/fund_me_dummies.ts"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "script:mainnet:ownership:001": "hardhat --network mainnet run --no-compile ./scripts/ownership/transfer_ownership_of_latte_bean_to_master_barista.ts",
 
     "script:mainnet:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/timelock/timelock_execution.ts",
+    "script:mainnet:timelock:timelock000": "hardhat --network mainnet run --no-compile ./scripts/timelock/timelock/change_delay.ts",
 
     "script:mainnet:swap:000": "hardhat --network mainnet run --no-compile ./scripts/swap/add_liquidity.ts",
     "script:mainnet:swap:001": "hardhat --network mainnet run --no-compile ./scripts/swap/get_deterministic_lp_address.ts",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "script:mainnet:ownership:001": "hardhat --network mainnet run --no-compile ./scripts/ownership/transfer_ownership_of_latte_bean_to_master_barista.ts",
 
     "script:mainnet:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/timelock/timelock_execution.ts",
-    "script:mainnet:timelock:timelock000": "hardhat --network mainnet run --no-compile ./scripts/timelock/timelock/change_delay.ts",
+    "script:mainnet:timelock:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/timelock/timelock/change_delay.ts",
 
     "script:mainnet:swap:000": "hardhat --network mainnet run --no-compile ./scripts/swap/add_liquidity.ts",
     "script:mainnet:swap:001": "hardhat --network mainnet run --no-compile ./scripts/swap/get_deterministic_lp_address.ts",

--- a/scripts/market/timelock/upgrade.ts
+++ b/scripts/market/timelock/upgrade.ts
@@ -1,0 +1,53 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers, upgrades, network } from "hardhat";
+import { LatteMarket__factory, Timelock__factory } from "../../../typechain";
+import { getConfig, withNetworkFile } from "../../../utils";
+
+async function main() {
+  /*
+  ░██╗░░░░░░░██╗░█████╗░██████╗░███╗░░██╗██╗███╗░░██╗░██████╗░
+  ░██║░░██╗░░██║██╔══██╗██╔══██╗████╗░██║██║████╗░██║██╔════╝░
+  ░╚██╗████╗██╔╝███████║██████╔╝██╔██╗██║██║██╔██╗██║██║░░██╗░
+  ░░████╔═████║░██╔══██║██╔══██╗██║╚████║██║██║╚████║██║░░╚██╗
+  ░░╚██╔╝░╚██╔╝░██║░░██║██║░░██║██║░╚███║██║██║░╚███║╚██████╔╝
+  ░░░╚═╝░░░╚═╝░░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚══╝╚═╝╚═╝░░╚══╝░╚═════╝░
+  Check all variables below before execute the deployment script
+  */
+  const config = getConfig();
+  const TARGETED_LATTE_MARKET = config.LatteMarket;
+  const EXACT_ETA = "";
+
+  const timelock = Timelock__factory.connect(config.Timelock, (await ethers.getSigners())[0]);
+
+  console.log(`============`);
+  console.log(`>> Upgrading LatteMarket through Timelock + ProxyAdmin`);
+  console.log(">> Prepare upgrade & deploy if needed a new IMPL automatically.");
+  const LatteMarketFactory = (await ethers.getContractFactory("LatteMarket")) as LatteMarket__factory;
+  const preparedLatteMarket = await upgrades.prepareUpgrade(TARGETED_LATTE_MARKET, LatteMarketFactory);
+  console.log(`>> Implementation address: ${preparedLatteMarket}`);
+  console.log("✅ Done");
+
+  console.log(`>> Queue tx on Timelock to upgrade the implementation`);
+  await timelock.queueTransaction(
+    config.ProxyAdmin,
+    "0",
+    "upgrade(address,address)",
+    ethers.utils.defaultAbiCoder.encode(["address", "address"], [TARGETED_LATTE_MARKET, preparedLatteMarket]),
+    EXACT_ETA
+  );
+  console.log("✅ Done");
+
+  console.log(`>> Generate executeTransaction:`);
+  console.log(
+    `await timelock.executeTransaction('${config.ProxyAdmin}', '0', 'upgrade(address,address)', ethers.utils.defaultAbiCoder.encode(['address','address'], ['${TARGETED_LATTE_MARKET}','${preparedLatteMarket}']), ${EXACT_ETA})`
+  );
+  console.log("✅ Done");
+}
+
+withNetworkFile(main)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/nft/timelock/upgrade_booster.ts
+++ b/scripts/nft/timelock/upgrade_booster.ts
@@ -1,0 +1,53 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers, upgrades, network } from "hardhat";
+import { Booster__factory, Timelock__factory } from "../../../typechain";
+import { getConfig, withNetworkFile } from "../../../utils";
+
+async function main() {
+  /*
+  ░██╗░░░░░░░██╗░█████╗░██████╗░███╗░░██╗██╗███╗░░██╗░██████╗░
+  ░██║░░██╗░░██║██╔══██╗██╔══██╗████╗░██║██║████╗░██║██╔════╝░
+  ░╚██╗████╗██╔╝███████║██████╔╝██╔██╗██║██║██╔██╗██║██║░░██╗░
+  ░░████╔═████║░██╔══██║██╔══██╗██║╚████║██║██║╚████║██║░░╚██╗
+  ░░╚██╔╝░╚██╔╝░██║░░██║██║░░██║██║░╚███║██║██║░╚███║╚██████╔╝
+  ░░░╚═╝░░░╚═╝░░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚══╝╚═╝╚═╝░░╚══╝░╚═════╝░
+  Check all variables below before execute the deployment script
+  */
+  const config = getConfig();
+  const TARGETED_BOOSTER = config.Booster;
+  const EXACT_ETA = "";
+
+  const timelock = Timelock__factory.connect(config.Timelock, (await ethers.getSigners())[0]);
+
+  console.log(`============`);
+  console.log(`>> Upgrading Booster through Timelock + ProxyAdmin`);
+  console.log(">> Prepare upgrade & deploy if needed a new IMPL automatically.");
+  const BoosterFactory = (await ethers.getContractFactory("Booster")) as Booster__factory;
+  const preparedOGNFTOffering = await upgrades.prepareUpgrade(TARGETED_BOOSTER, BoosterFactory);
+  console.log(`>> Implementation address: ${preparedOGNFTOffering}`);
+  console.log("✅ Done");
+
+  console.log(`>> Queue tx on Timelock to upgrade the implementation`);
+  await timelock.queueTransaction(
+    config.ProxyAdmin,
+    "0",
+    "upgrade(address,address)",
+    ethers.utils.defaultAbiCoder.encode(["address", "address"], [TARGETED_BOOSTER, preparedOGNFTOffering]),
+    EXACT_ETA
+  );
+  console.log("✅ Done");
+
+  console.log(`>> Generate executeTransaction:`);
+  console.log(
+    `await timelock.executeTransaction('${config.ProxyAdmin}', '0', 'upgrade(address,address)', ethers.utils.defaultAbiCoder.encode(['address','address'], ['${TARGETED_BOOSTER}','${preparedOGNFTOffering}']), ${EXACT_ETA})`
+  );
+  console.log("✅ Done");
+}
+
+withNetworkFile(main)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/og-nft-offering/timelock/upgrade.ts
+++ b/scripts/og-nft-offering/timelock/upgrade.ts
@@ -1,0 +1,53 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { ethers, upgrades, network } from "hardhat";
+import { OGNFTOffering__factory, Timelock__factory } from "../../../typechain";
+import { getConfig, withNetworkFile } from "../../../utils";
+
+async function main() {
+  /*
+  ░██╗░░░░░░░██╗░█████╗░██████╗░███╗░░██╗██╗███╗░░██╗░██████╗░
+  ░██║░░██╗░░██║██╔══██╗██╔══██╗████╗░██║██║████╗░██║██╔════╝░
+  ░╚██╗████╗██╔╝███████║██████╔╝██╔██╗██║██║██╔██╗██║██║░░██╗░
+  ░░████╔═████║░██╔══██║██╔══██╗██║╚████║██║██║╚████║██║░░╚██╗
+  ░░╚██╔╝░╚██╔╝░██║░░██║██║░░██║██║░╚███║██║██║░╚███║╚██████╔╝
+  ░░░╚═╝░░░╚═╝░░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚══╝╚═╝╚═╝░░╚══╝░╚═════╝░
+  Check all variables below before execute the deployment script
+  */
+  const config = getConfig();
+  const TARGETED_OG_NFT_OFFERING = config.OGNFTOffering;
+  const EXACT_ETA = "";
+
+  const timelock = Timelock__factory.connect(config.Timelock, (await ethers.getSigners())[0]);
+
+  console.log(`============`);
+  console.log(`>> Upgrading OG NFT Offering through Timelock + ProxyAdmin`);
+  console.log(">> Prepare upgrade & deploy if needed a new IMPL automatically.");
+  const OGNFTOfferingFactory = (await ethers.getContractFactory("OGNFTOffering")) as OGNFTOffering__factory;
+  const preparedOGNFTOffering = await upgrades.prepareUpgrade(TARGETED_OG_NFT_OFFERING, OGNFTOfferingFactory);
+  console.log(`>> Implementation address: ${preparedOGNFTOffering}`);
+  console.log("✅ Done");
+
+  console.log(`>> Queue tx on Timelock to upgrade the implementation`);
+  await timelock.queueTransaction(
+    config.ProxyAdmin,
+    "0",
+    "upgrade(address,address)",
+    ethers.utils.defaultAbiCoder.encode(["address", "address"], [TARGETED_OG_NFT_OFFERING, preparedOGNFTOffering]),
+    EXACT_ETA
+  );
+  console.log("✅ Done");
+
+  console.log(`>> Generate executeTransaction:`);
+  console.log(
+    `await timelock.executeTransaction('${config.ProxyAdmin}', '0', 'upgrade(address,address)', ethers.utils.defaultAbiCoder.encode(['address','address'], ['${TARGETED_OG_NFT_OFFERING}','${preparedOGNFTOffering}']), ${EXACT_ETA})`
+  );
+  console.log("✅ Done");
+}
+
+withNetworkFile(main)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/ownership/transfer_ownership_to_timelock.ts
+++ b/scripts/ownership/transfer_ownership_to_timelock.ts
@@ -14,10 +14,10 @@ async function main() {
   */
 
   const TO_BE_TRANSFERED: Array<string> = [
-    "0xEb85Af63fb38eFa97AccaAe2c66F4b3636a435E9", // Master Barista
-    "0xCe16028373F210c42f366aDB78819c02611d2b79", // Booster Config
-    "0x4e2B5591Eb8378314a8042D422F36D3F6E150756", // Latte Market
-    "0x360946e5d90eb6Be5931D88A152E43146415da5E", // OG NFT Offering
+    "0xdeAaFFD54d11B3dfa50E7A4b178E045ab750e4eA", // Booster Config
+    "0xbCeE0d15a4402C9Cc894D52cc5E9982F60C463d6", // Master Barista
+    "0x288f26D5Ed901e290D713Db86142302AF8266b31", // Latte Market
+    "0xa4FD125A4384faf310c1e8F7b3cE87e8b423B100", // OGNFTOffering
   ];
 
   const config = getConfig();

--- a/scripts/timelock/timelock/change_delay.ts
+++ b/scripts/timelock/timelock/change_delay.ts
@@ -19,7 +19,7 @@ async function main() {
   const config = getConfig();
   const timelockTransactions: Array<ITimelockResponse> = [];
   const DELAY = 86400; // 24 hrs
-  const TIMELOCK_ETA = "";
+  const TIMELOCK_ETA = "1632067801";
 
   console.log(`>> Queue Master Transaction to setDelay in timelock ${config.Timelock} `);
   timelockTransactions.push(

--- a/scripts/timelock/timelock/change_delay.ts
+++ b/scripts/timelock/timelock/change_delay.ts
@@ -1,0 +1,46 @@
+import { getConfig, withNetworkFile, FileService, TimelockService, ITimelockResponse } from "../../../utils";
+
+interface IStakingPool {
+  STAKING_TOKEN_ADDRESS: string;
+}
+
+type IStakingPools = Array<IStakingPool>;
+
+async function main() {
+  /*
+  ░██╗░░░░░░░██╗░█████╗░██████╗░███╗░░██╗██╗███╗░░██╗░██████╗░
+  ░██║░░██╗░░██║██╔══██╗██╔══██╗████╗░██║██║████╗░██║██╔════╝░
+  ░╚██╗████╗██╔╝███████║██████╔╝██╔██╗██║██║██╔██╗██║██║░░██╗░
+  ░░████╔═████║░██╔══██║██╔══██╗██║╚████║██║██║╚████║██║░░╚██╗
+  ░░╚██╔╝░╚██╔╝░██║░░██║██║░░██║██║░╚███║██║██║░╚███║╚██████╔╝
+  ░░░╚═╝░░░╚═╝░░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚══╝╚═╝╚═╝░░╚══╝░╚═════╝░
+  Check all variables below before execute the deployment script
+  */
+  const config = getConfig();
+  const timelockTransactions: Array<ITimelockResponse> = [];
+  const DELAY = 86400; // 24 hrs
+  const TIMELOCK_ETA = "";
+
+  console.log(`>> Queue Master Transaction to setDelay in timelock ${config.Timelock} `);
+  timelockTransactions.push(
+    await TimelockService.queueTransaction(
+      `setDelay in Timelock ${config.Timelock} from 6 hrs to ${DELAY / 60 / 60}`,
+      config.Timelock,
+      "0",
+      "setDelay(uint256)",
+      ["uint256"],
+      [DELAY],
+      TIMELOCK_ETA
+    )
+  );
+  console.log("✅ Done");
+
+  await FileService.write("set-timelock-delay", timelockTransactions);
+}
+
+withNetworkFile(main)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/unit/Booster.test.ts
+++ b/tests/unit/Booster.test.ts
@@ -94,9 +94,9 @@ describe("Booster", () => {
             [stakingTokens[0].address]: false,
           },
         });
-        await expect(
-          booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer)
-        ).to.be.revertedWith("Booster::isStakeTokenOK::bad stake token");
+        await expect(booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1)).to.be.revertedWith(
+          "Booster::isStakeTokenOK::bad stake token"
+        );
       });
     });
 
@@ -124,34 +124,9 @@ describe("Booster", () => {
           },
         });
 
-        await expect(
-          booster.stakeNFT(stakingTokens[0].address, latteNft.address, 1, signatureAsDeployer)
-        ).to.be.revertedWith("Booster::isBoosterNftOK::bad nft");
-      });
-    });
-
-    context("when invalid signature", () => {
-      it("should revert", async () => {
-        // set stake token allowance to be true
-        await boosterConfig.smodify.put({
-          stakeTokenAllowance: {
-            [stakingTokens[0].address]: true,
-          },
-        });
-        // set booster nft allowance to be false / revert case
-        await boosterConfig.smodify.put({
-          boosterNftAllowanceConfig: {
-            [stakingTokens[0].address]: {
-              [nftToken.address]: {
-                1: true,
-              },
-            },
-          },
-        });
-
-        await expect(
-          booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice)
-        ).to.be.revertedWith("Booster::permit::INVALID_SIGNATURE");
+        await expect(booster.stakeNFT(stakingTokens[0].address, latteNft.address, 1)).to.be.revertedWith(
+          "Booster::isBoosterNftOK::bad nft"
+        );
       });
     });
 
@@ -181,12 +156,12 @@ describe("Booster", () => {
                 },
               },
             });
-            await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer);
+            await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
             // owner of a booster contract should be changed
             expect(await (nftToken as unknown as MockERC721).ownerOf(1)).to.eq(booster.address);
-            await expect(
-              booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer)
-            ).to.be.revertedWith("Booster::stakeNFT:: nft already staked");
+            await expect(booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1)).to.be.revertedWith(
+              "Booster::stakeNFT:: nft already staked"
+            );
           });
         });
 
@@ -220,12 +195,12 @@ describe("Booster", () => {
                 },
               },
             });
-            await booster.stakeNFT(stakingTokens[1].address, nftToken.address, 1, signatureAsDeployer);
+            await booster.stakeNFT(stakingTokens[1].address, nftToken.address, 1);
             // owner of a booster contract should be changed
             expect(await (nftToken as unknown as MockERC721).ownerOf(1)).to.eq(booster.address);
-            await expect(
-              booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer)
-            ).to.be.revertedWith("ERC721: transfer of token that is not own");
+            await expect(booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1)).to.be.revertedWith(
+              "ERC721: transfer of token that is not own"
+            );
           });
         });
       });
@@ -254,7 +229,7 @@ describe("Booster", () => {
               },
             },
           });
-          await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer);
+          await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
           // owner of a booster contract should be changed
           expect(await (nftToken as unknown as MockERC721).ownerOf(1)).to.eq(booster.address);
           // should expect some storage changes in a booster
@@ -305,7 +280,7 @@ describe("Booster", () => {
               },
             });
             // stake for the first time, its' energy will be used to amplify
-            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
             // should expect some storage changes in a booster
             expect(
               (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -341,7 +316,7 @@ describe("Booster", () => {
 
             // MOCK that master barista has enough LATTE
             await latteToken.transfer(beanBag.address, parseEther("100"));
-            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 2, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 2);
             // owner is expected to get 100 reward + 10 extra rewards from staking an nft
             expect(await latteToken.balanceOf(ownerAddress)).to.eq(parseEther("100").add(parseEther("10")));
             // dev is expected to get 15% of 10 extra reward, thus making the dev able to collect 1.5
@@ -398,7 +373,7 @@ describe("Booster", () => {
               },
             });
             // stake for the first time, its' energy will be used to amplify
-            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
             // should expect some storage changes in a booster
             expect(
               (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -434,7 +409,7 @@ describe("Booster", () => {
 
             // MOCK that master barista has enough LATTE
             await latteToken.transfer(beanBag.address, parseEther("100"));
-            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 2, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 2);
             // owner is expected to get 100 reward
             expect(await latteToken.balanceOf(ownerAddress)).to.eq(parseEther("100"));
             expect(await latteToken.balanceOf(await dev.getAddress())).to.eq(parseEther("0"));
@@ -463,23 +438,8 @@ describe("Booster", () => {
           },
         });
 
-        await expect(booster.unstakeNFT(stakingTokens[0].address, signatureAsDeployer)).to.be.revertedWith(
+        await expect(booster.unstakeNFT(stakingTokens[0].address)).to.be.revertedWith(
           "Booster::isStakeTokenOK::bad stake token"
-        );
-      });
-    });
-
-    context("when invalid signature", () => {
-      it("should revert", async () => {
-        // set stake token allowance to be true
-        await boosterConfig.smodify.put({
-          stakeTokenAllowance: {
-            [stakingTokens[0].address]: true,
-          },
-        });
-
-        await expect(booster.unstakeNFT(stakingTokens[0].address, signatureAsAlice)).to.be.revertedWith(
-          "Booster::permit::INVALID_SIGNATURE"
         );
       });
     });
@@ -508,7 +468,7 @@ describe("Booster", () => {
             },
           },
         });
-        await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsDeployer);
+        await booster.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
         // owner of a booster contract should be changed
         expect(await (nftToken as unknown as MockERC721).ownerOf(1)).to.eq(booster.address);
         // should expect some storage changes in a booster
@@ -517,7 +477,7 @@ describe("Booster", () => {
         );
         expect((await booster.userStakingNFT(stakingTokens[0].address, deployerAddr)).nftTokenId).to.eq(1);
 
-        await booster.unstakeNFT(stakingTokens[0].address, signatureAsDeployer);
+        await booster.unstakeNFT(stakingTokens[0].address);
         // owner of a booster contract should be changed
         expect(await (nftToken as unknown as MockERC721).ownerOf(1)).to.eq(deployerAddr);
         // should expect some storage changes in a booster
@@ -567,7 +527,7 @@ describe("Booster", () => {
             },
           });
           // stake for the first time, its' energy will be used to amplify
-          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
           // should expect some storage changes in a booster
           expect((await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
             nftToken.address.toLowerCase()
@@ -603,7 +563,7 @@ describe("Booster", () => {
 
           // MOCK that master barista has enough LATTE
           await latteToken.transfer(beanBag.address, parseEther("100"));
-          await boosterAsAlice.unstakeNFT(stakingTokens[0].address, signatureAsAlice);
+          await boosterAsAlice.unstakeNFT(stakingTokens[0].address);
           // owner is expected to get 100 reward + 10 extra rewards from staking an nft
           expect(await latteToken.balanceOf(ownerAddress)).to.eq(parseEther("100").add(parseEther("10")));
           // dev is expected to get 15% of 10 extra reward, thus making the dev able to collect 1.5
@@ -661,7 +621,7 @@ describe("Booster", () => {
             },
           });
           // stake for the first time, its' energy will be used to amplify
-          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
           // should expect some storage changes in a booster
           expect((await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
             nftToken.address.toLowerCase()
@@ -697,7 +657,7 @@ describe("Booster", () => {
 
           // MOCK that master barista has enough LATTE
           await latteToken.transfer(beanBag.address, parseEther("100"));
-          await boosterAsAlice.unstakeNFT(stakingTokens[0].address, signatureAsAlice);
+          await boosterAsAlice.unstakeNFT(stakingTokens[0].address);
           // owner is expected to get 100 reward
           expect(await latteToken.balanceOf(ownerAddress)).to.eq(parseEther("100"));
           expect(await latteToken.balanceOf(await dev.getAddress())).to.eq(parseEther("0"));
@@ -768,8 +728,8 @@ describe("Booster", () => {
           },
         });
         // stake for the first time, its' energy will be used to amplify
-        await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
-        await boosterAsAlice.stakeNFT(stakingTokens[1].address, nftToken.address, 2, signatureAsAlice);
+        await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
+        await boosterAsAlice.stakeNFT(stakingTokens[1].address, nftToken.address, 2);
         // should expect some storage changes in a booster
         expect((await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
           nftToken.address.toLowerCase()
@@ -901,7 +861,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -986,7 +946,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -1082,7 +1042,7 @@ describe("Booster", () => {
             },
           });
           // stake for the first time, its' energy will be used to amplify
-          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+          await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
           // should expect some storage changes in a booster
           expect((await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
             nftToken.address.toLowerCase()
@@ -1191,7 +1151,7 @@ describe("Booster", () => {
             },
           });
           // stake for the first time, its' energy will be used to amplify
-          await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1, signatureAsAlice);
+          await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1);
           // should expect some storage changes in a booster
           expect((await booster.userStakingNFT(latteToken.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
             nftToken.address.toLowerCase()
@@ -1380,7 +1340,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -1476,7 +1436,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -1674,7 +1634,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -1771,7 +1731,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -1917,7 +1877,7 @@ describe("Booster", () => {
               },
             });
             // stake for the first time, its' energy will be used to amplify
-            await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1);
             // should expect some storage changes in a booster
             expect((await booster.userStakingNFT(latteToken.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
               nftToken.address.toLowerCase()
@@ -2008,7 +1968,7 @@ describe("Booster", () => {
               },
             });
             // stake for the first time, its' energy will be used to amplify
-            await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1, signatureAsAlice);
+            await boosterAsAlice.stakeNFT(latteToken.address, nftToken.address, 1);
             // should expect some storage changes in a booster
             expect((await booster.userStakingNFT(latteToken.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
               nftToken.address.toLowerCase()
@@ -2209,7 +2169,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -2308,7 +2268,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -2410,7 +2370,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -2507,7 +2467,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(wbnb.address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect((await booster.userStakingNFT(wbnb.address, ownerAddress)).nftAddress.toLowerCase()).to.eq(
                 nftToken.address.toLowerCase()
@@ -2667,7 +2627,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()
@@ -2769,7 +2729,7 @@ describe("Booster", () => {
                 },
               });
               // stake for the first time, its' energy will be used to amplify
-              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1, signatureAsAlice);
+              await boosterAsAlice.stakeNFT(stakingTokens[0].address, nftToken.address, 1);
               // should expect some storage changes in a booster
               expect(
                 (await booster.userStakingNFT(stakingTokens[0].address, ownerAddress)).nftAddress.toLowerCase()

--- a/tests/unit/LatteMarket.test.ts
+++ b/tests/unit/LatteMarket.test.ts
@@ -235,7 +235,7 @@ describe("LatteMarket", () => {
   describe("#buyNFT", () => {
     context("when buying a non-support nft", () => {
       it("should revert", async () => {
-        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0)).to.revertedWith(
           "LatteMarket::onlySupportedNFT::unsupported nft"
         );
       });
@@ -255,7 +255,7 @@ describe("LatteMarket", () => {
         );
 
         // buying phase
-        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0)).to.revertedWith(
           "LatteMarket::withinBlockRange:: invalid block number"
         );
       });
@@ -273,26 +273,8 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0)).to.revertedWith(
           "LatteMarket::onlyNonBiddingNFT::only selling token can be used here"
-        );
-      });
-    });
-
-    context("when invalid signature", () => {
-      it("should revert", async () => {
-        await latteMarket.setSupportNFT([latteNFT.address], true);
-        await latteMarket.readyToSellNFT(
-          latteNFT.address,
-          0,
-          parseEther("10"),
-          1,
-          startingBlock.add(3),
-          startingBlock.add(10),
-          stakingTokens[0].address
-        );
-        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsDeployer)).to.revertedWith(
-          "LatteMarket::permit::INVALID_SIGNATURE"
         );
       });
     });
@@ -309,7 +291,7 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0)).to.revertedWith(
           "LatteMarket::_decreaseCap::maximum mint cap reached"
         );
       });
@@ -337,7 +319,7 @@ describe("LatteMarket", () => {
 
             // buy phase
             await expect(
-              latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice, {
+              latteMarketAsAlice.buyNFT(latteNFT.address, 0, {
                 value: parseEther("11"),
               })
             ).to.revertedWith("latteMarket::_safeWrap:: value != msg.value");
@@ -364,7 +346,7 @@ describe("LatteMarket", () => {
 
         // buy phase
         const balBefore = await alice.getBalance();
-        const tx = await latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice, {
+        const tx = await latteMarketAsAlice.buyNFT(latteNFT.address, 0, {
           value: parseEther("10"),
         });
         const receipt = await tx.wait();
@@ -398,7 +380,7 @@ describe("LatteMarket", () => {
 
           // buy phase
           await expect(
-            latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice, {
+            latteMarketAsAlice.buyNFT(latteNFT.address, 0, {
               value: parseEther("10"),
             })
           ).to.revertedWith("latteMarket::_safeWrap:: baseToken is not wNative");
@@ -434,7 +416,7 @@ describe("LatteMarket", () => {
           expect(metadata.price).to.eq(parseEther("0"));
 
           // buy phase
-          await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice)).to.revertedWith(
+          await expect(latteMarketAsAlice.buyNFT(latteNFT.address, 0)).to.revertedWith(
             "LatteMarket::withinBlockRange:: invalid block number"
           );
         });
@@ -460,7 +442,7 @@ describe("LatteMarket", () => {
         const stakingTokenAsAlice = SimpleToken__factory.connect(stakingTokens[0].address, alice);
         await stakingTokens[0].mint(await alice.getAddress(), parseEther("10"));
         await stakingTokenAsAlice.approve(latteMarket.address, parseEther("10"));
-        await latteMarketAsAlice.buyNFT(latteNFT.address, 0, signatureAsAlice);
+        await latteMarketAsAlice.buyNFT(latteNFT.address, 0);
         expect(await stakingTokens[0].balanceOf(await dev.getAddress())).to.eq(parseEther("1"));
         expect(await stakingTokens[0].balanceOf(seller)).to.eq(parseEther("9"));
         expect(await _latteNFT.ownerOf(0)).to.eq(await alice.getAddress());
@@ -472,7 +454,7 @@ describe("LatteMarket", () => {
   describe("#buyBatchNFT", () => {
     context("when buying a non-support nft", () => {
       it("should revert", async () => {
-        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2)).to.revertedWith(
           "LatteMarket::onlySupportedNFT::unsupported nft"
         );
       });
@@ -492,7 +474,7 @@ describe("LatteMarket", () => {
         );
 
         // buying phase
-        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2)).to.revertedWith(
           "LatteMarket::buyBatchNFT:: invalid block number"
         );
       });
@@ -510,26 +492,8 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2)).to.revertedWith(
           "LatteMarket::onlyNonBiddingNFT::only selling token can be used here"
-        );
-      });
-    });
-
-    context("when invalid signature", () => {
-      it("should revert", async () => {
-        await latteMarket.setSupportNFT([latteNFT.address], true);
-        await latteMarket.readyToSellNFT(
-          latteNFT.address,
-          0,
-          parseEther("10"),
-          1,
-          startingBlock.add(3),
-          startingBlock.add(10),
-          stakingTokens[0].address
-        );
-        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsDeployer)).to.revertedWith(
-          "LatteMarket::permit::INVALID_SIGNATURE"
         );
       });
     });
@@ -546,7 +510,7 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2)).to.revertedWith(
           "LatteMarket::_decreaseCap::maximum mint cap reached"
         );
       });
@@ -574,7 +538,7 @@ describe("LatteMarket", () => {
 
             // buy phase
             await expect(
-              latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice, {
+              latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, {
                 value: parseEther("11"),
               })
             ).to.revertedWith("latteMarket::_safeWrap:: value != msg.value");
@@ -600,7 +564,7 @@ describe("LatteMarket", () => {
 
         // buy phase
         const balBefore = await alice.getBalance();
-        const tx = await latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice, {
+        const tx = await latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, {
           value: parseEther("20"),
         });
         const receipt = await tx.wait();
@@ -635,7 +599,7 @@ describe("LatteMarket", () => {
 
           // buy phase
           await expect(
-            latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice, {
+            latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, {
               value: parseEther("10"),
             })
           ).to.revertedWith("latteMarket::_safeWrap:: baseToken is not wNative");
@@ -672,7 +636,7 @@ describe("LatteMarket", () => {
           expect(metadata.price).to.eq(parseEther("0"));
 
           // buy phase
-          await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice)).to.revertedWith(
+          await expect(latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2)).to.revertedWith(
             "LatteMarket::buyBatchNFT:: invalid block number"
           );
         });
@@ -698,7 +662,7 @@ describe("LatteMarket", () => {
         const stakingTokenAsAlice = SimpleToken__factory.connect(stakingTokens[0].address, alice);
         await stakingTokens[0].mint(await alice.getAddress(), parseEther("20"));
         await stakingTokenAsAlice.approve(latteMarket.address, parseEther("20"));
-        await latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2, signatureAsAlice);
+        await latteMarketAsAlice.buyBatchNFT(latteNFT.address, 0, 2);
         expect(await stakingTokens[0].balanceOf(await dev.getAddress())).to.eq(parseEther("2"));
         expect(await stakingTokens[0].balanceOf(seller)).to.eq(parseEther("18"));
         expect(await _latteNFT.ownerOf(0)).to.eq(await alice.getAddress());
@@ -873,7 +837,7 @@ describe("LatteMarket", () => {
   describe("#bidNFT()", () => {
     context("when bidding a non-support nft", () => {
       it("should revert", async () => {
-        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"), signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"))).to.revertedWith(
           "LatteMarket::onlySupportedNFT::unsupported nft"
         );
       });
@@ -893,7 +857,7 @@ describe("LatteMarket", () => {
         );
 
         // buying phase
-        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"), signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"))).to.revertedWith(
           "LatteMarket::withinBlockRange:: invalid block number"
         );
       });
@@ -911,7 +875,7 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"), signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"))).to.revertedWith(
           "LatteMarket::onlyBiddingNFT::only bidding token can be used here"
         );
       });
@@ -928,7 +892,7 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarket.bidNFT(latteNFT.address, 0, parseEther("1"), signatureAsDeployer)).to.revertedWith(
+        await expect(latteMarket.bidNFT(latteNFT.address, 0, parseEther("1"))).to.revertedWith(
           "LatteMarket::_bidNFT::Owner cannot bid"
         );
       });
@@ -945,7 +909,7 @@ describe("LatteMarket", () => {
           startingBlock.add(10),
           stakingTokens[0].address
         );
-        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"), signatureAsAlice)).to.revertedWith(
+        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("1"))).to.revertedWith(
           "LatteMarket::_bidNFT::price cannot be lower than or equal to the starting bid"
         );
       });
@@ -970,7 +934,7 @@ describe("LatteMarket", () => {
             );
 
             // bid phase
-            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsAlice, {
+            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), {
               value: parseEther("12"),
             });
             const bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
@@ -978,7 +942,7 @@ describe("LatteMarket", () => {
             expect(bid.price).to.eq(parseEther("12"));
 
             await expect(
-              latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsBob, {
+              latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("11"), {
                 value: parseEther("11"),
               })
             ).to.revertedWith("LatteMarket::_bidNFT::price cannot be lower than or equal to the latest bid");
@@ -1005,7 +969,7 @@ describe("LatteMarket", () => {
 
               // bid phase
               let aliceBalBefore = await alice.getBalance();
-              let aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice, {
+              let aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), {
                 value: parseEther("11"),
               });
               let aliceReceipt = await aliceTx.wait();
@@ -1019,7 +983,7 @@ describe("LatteMarket", () => {
               );
 
               aliceBalBefore = await alice.getBalance();
-              aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsAlice, {
+              aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), {
                 value: parseEther("12"),
               });
               aliceReceipt = await aliceTx.wait();
@@ -1056,7 +1020,7 @@ describe("LatteMarket", () => {
 
             // bid phase
             const aliceBalBefore = await alice.getBalance();
-            const aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice, {
+            const aliceTx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), {
               value: parseEther("11"),
             });
             const aliceReceipt = await aliceTx.wait();
@@ -1070,7 +1034,7 @@ describe("LatteMarket", () => {
             );
 
             const bobBalBefore = await bob.getBalance();
-            const bobTx = await latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsBob, {
+            const bobTx = await latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("12"), {
               value: parseEther("12"),
             });
             const bobReceipt = await bobTx.wait();
@@ -1104,7 +1068,7 @@ describe("LatteMarket", () => {
 
         // bid phase
         const balBefore = await alice.getBalance();
-        const tx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice, {
+        const tx = await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), {
           value: parseEther("11"),
         });
         const receipt = await tx.wait();
@@ -1144,13 +1108,13 @@ describe("LatteMarket", () => {
             );
 
             // bid phase
-            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsAlice);
+            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"));
             const bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
             expect(bid.bidder).to.eq(await alice.getAddress());
             expect(bid.price).to.eq(parseEther("12"));
 
             await expect(
-              latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsBob, {
+              latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("11"), {
                 value: parseEther("11"),
               })
             ).to.revertedWith("LatteMarket::_bidNFT::price cannot be lower than or equal to the latest bid");
@@ -1183,7 +1147,7 @@ describe("LatteMarket", () => {
               );
 
               // bid phase
-              await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice);
+              await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"));
               let bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
               expect(bid.bidder).to.eq(await alice.getAddress());
               expect(bid.price).to.eq(parseEther("11"));
@@ -1194,7 +1158,7 @@ describe("LatteMarket", () => {
                 parseEther("1")
               );
 
-              await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsAlice);
+              await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("12"));
               bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
               expect(bid.bidder).to.eq(await alice.getAddress());
               expect(bid.price).to.eq(parseEther("12"));
@@ -1233,7 +1197,7 @@ describe("LatteMarket", () => {
             );
 
             // bid phase
-            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice);
+            await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"));
             let bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
             expect(bid.bidder).to.eq(await alice.getAddress());
             expect(bid.price).to.eq(parseEther("11"));
@@ -1244,7 +1208,7 @@ describe("LatteMarket", () => {
               parseEther("1")
             );
 
-            await latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("12"), signatureAsBob);
+            await latteMarketAsBob.bidNFT(latteNFT.address, 0, parseEther("12"));
             bid = await latteMarketAsBob.getBid(latteNFT.address, 0);
             expect(bid.bidder).to.eq(await bob.getAddress());
             expect(bid.price).to.eq(parseEther("12"));
@@ -1277,7 +1241,7 @@ describe("LatteMarket", () => {
         );
 
         // bid phase
-        await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice);
+        await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"));
         const bid = await latteMarketAsAlice.getBid(latteNFT.address, 0);
         expect(bid.bidder).to.eq(await alice.getAddress());
         expect(bid.price).to.eq(parseEther("11"));
@@ -1387,7 +1351,7 @@ describe("LatteMarket", () => {
         );
 
         // bid phase
-        await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice, {
+        await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), {
           value: parseEther("11"),
         });
 
@@ -1421,7 +1385,7 @@ describe("LatteMarket", () => {
             parseEther("11")
           );
           // bid phase
-          await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice);
+          await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"));
           expect(await stakingTokens[0].balanceOf(await alice.getAddress())).to.eq(parseEther("89"));
           await expect(latteMarket.cancelBiddingNFT(latteNFT.address, 0)).to.revertedWith(
             "LatteMarket::cancelBiddingNFT::auction already has a bidder"
@@ -1470,9 +1434,9 @@ describe("LatteMarket", () => {
           parseEther("11")
         );
         // bid phase
-        await expect(
-          latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice)
-        ).to.revertedWith("LatteMarket::withinBlockRange:: invalid block number");
+        await expect(latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"))).to.revertedWith(
+          "LatteMarket::withinBlockRange:: invalid block number"
+        );
       });
     });
 
@@ -1493,7 +1457,7 @@ describe("LatteMarket", () => {
       );
 
       // bid phase
-      await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), signatureAsAlice, {
+      await latteMarketAsAlice.bidNFT(latteNFT.address, 0, parseEther("11"), {
         value: parseEther("11"),
       });
 

--- a/tests/unit/OGNFTOffering.test.ts
+++ b/tests/unit/OGNFTOffering.test.ts
@@ -149,17 +149,8 @@ describe("OGNFTOffering", () => {
         );
 
         // buying phase
-        await expect(ogOfferingAsAlice.buyNFT(0, signatureAsAlice)).to.revertedWith(
+        await expect(ogOfferingAsAlice.buyNFT(0)).to.revertedWith(
           "OGNFTOffering::withinBlockRange:: invalid block number"
-        );
-      });
-    });
-
-    context("when invalid signature", () => {
-      it("should revert", async () => {
-        await ogOffering.readyToSellNFT(0, 1, startingBlock.add(2), startingBlock.add(10), stakingTokens[0].address);
-        await expect(ogOfferingAsAlice.buyNFT(0, signatureAsDeployer)).to.revertedWith(
-          "OGNFTOffering::permit::INVALID_SIGNATURE"
         );
       });
     });
@@ -167,7 +158,7 @@ describe("OGNFTOffering", () => {
     context("when reaching a maximum cap", () => {
       it("should revert", async () => {
         await ogOffering.readyToSellNFT(0, 0, startingBlock.add(2), startingBlock.add(10), stakingTokens[0].address);
-        await expect(ogOfferingAsAlice.buyNFT(0, signatureAsAlice)).to.revertedWith(
+        await expect(ogOfferingAsAlice.buyNFT(0)).to.revertedWith(
           "OGNFTOffering::_decreaseCap::maximum mint cap reached"
         );
       });
@@ -182,7 +173,7 @@ describe("OGNFTOffering", () => {
 
             // buy phase
             await expect(
-              ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+              ogOfferingAsAlice.buyNFT(0, {
                 value: parseEther("11"),
               })
             ).to.revertedWith("OGNFTOffering::_safeWrap:: value != msg.value");
@@ -202,11 +193,11 @@ describe("OGNFTOffering", () => {
 
           const nonce = await alice.getTransactionCount();
           await Promise.all([
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               value: value,
               nonce: nonce,
             }),
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               value: value,
               nonce: nonce + 1,
             }),
@@ -218,7 +209,7 @@ describe("OGNFTOffering", () => {
           await expect(ogBuyLimit.counter).to.eq(2);
           // shouldn't buy because limit count is 2
           await expect(
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               value: value,
             })
           ).to.revertedWith("OGNFTOffering::_buyNFTTo::exceed buy limit");
@@ -226,7 +217,7 @@ describe("OGNFTOffering", () => {
           await advanceBlockTo(startingBlock.add(24).toNumber());
           const balBefore = await alice.getBalance();
           // should be able to buy again
-          const tx = await ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+          const tx = await ogOfferingAsAlice.buyNFT(0, {
             value: value,
           });
           const receipt = await tx.wait();
@@ -254,7 +245,7 @@ describe("OGNFTOffering", () => {
           // buy phase
           const balBefore1 = await alice.getBalance();
           const value1 = await (priceModel as unknown as TripleSlopePriceModel).getPrice(4, 3, 0);
-          const tx1 = await ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+          const tx1 = await ogOfferingAsAlice.buyNFT(0, {
             value: value1,
           });
           const gasUsed1 = (await tx1.wait()).gasUsed;
@@ -266,7 +257,7 @@ describe("OGNFTOffering", () => {
 
           const balBefore2 = await alice.getBalance();
           const value2 = await (priceModel as unknown as TripleSlopePriceModel).getPrice(4, 2, 0);
-          const tx2 = await ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+          const tx2 = await ogOfferingAsAlice.buyNFT(0, {
             value: value2,
           });
           const gasUsed2 = (await tx2.wait()).gasUsed;
@@ -278,7 +269,7 @@ describe("OGNFTOffering", () => {
 
           const balBefore3 = await alice.getBalance();
           const value3 = await (priceModel as unknown as TripleSlopePriceModel).getPrice(4, 1, 0);
-          const tx3 = await ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+          const tx3 = await ogOfferingAsAlice.buyNFT(0, {
             value: value3,
           });
           const gasUsed3 = (await tx3.wait()).gasUsed;
@@ -301,7 +292,7 @@ describe("OGNFTOffering", () => {
         const value = await (priceModel as unknown as TripleSlopePriceModel).getPrice(1, 0, 0);
         // buy phase
         const balBefore = await alice.getBalance();
-        const tx = await ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+        const tx = await ogOfferingAsAlice.buyNFT(0, {
           value: value,
         });
         const receipt = await tx.wait();
@@ -312,7 +303,7 @@ describe("OGNFTOffering", () => {
         expect(balAfter).to.eq(balBefore.sub(value.add((await ethers.provider.getGasPrice()).mul(gasUsed))));
         expect(await ogNFT.ownerOf(0)).to.eq(await alice.getAddress());
         // should be failed since cap is limited
-        await expect(ogOfferingAsAlice.buyNFT(0, signatureAsAlice)).to.revertedWith(
+        await expect(ogOfferingAsAlice.buyNFT(0)).to.revertedWith(
           "OGNFTOffering::_decreaseCap::maximum mint cap reached"
         );
       });
@@ -327,7 +318,7 @@ describe("OGNFTOffering", () => {
 
           // buy phase
           await expect(
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               value: await (priceModel as unknown as TripleSlopePriceModel).getPrice(1, 1, 0),
             })
           ).to.revertedWith("OGNFTOffering::_safeWrap:: baseToken is not wNative");
@@ -355,10 +346,10 @@ describe("OGNFTOffering", () => {
           await stakingTokenAsAlice.approve(ogOffering.address, value.mul(3));
           const nonce = await alice.getTransactionCount();
           await Promise.all([
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               nonce: nonce,
             }),
-            ogOfferingAsAlice.buyNFT(0, signatureAsAlice, {
+            ogOfferingAsAlice.buyNFT(0, {
               nonce: nonce + 1,
             }),
           ]);
@@ -368,13 +359,11 @@ describe("OGNFTOffering", () => {
           await expect(ogBuyLimit.cooldownStartBlock).to.eq(startingBlock.add(6));
           await expect(ogBuyLimit.counter).to.eq(2);
           // shouldn't buy because limit count is 2
-          await expect(ogOfferingAsAlice.buyNFT(0, signatureAsAlice)).to.revertedWith(
-            "OGNFTOffering::_buyNFTTo::exceed buy limit"
-          );
+          await expect(ogOfferingAsAlice.buyNFT(0)).to.revertedWith("OGNFTOffering::_buyNFTTo::exceed buy limit");
 
           await advanceBlockTo(startingBlock.add(26).toNumber());
           // should be able to buy again
-          await ogOfferingAsAlice.buyNFT(0, signatureAsAlice);
+          await ogOfferingAsAlice.buyNFT(0);
           expect(await stakingTokens[0].balanceOf(await dev.getAddress())).to.eq(value.mul(3).div(10));
           expect(await stakingTokens[0].balanceOf(seller)).to.eq(value.mul(3).sub(value.mul(3).div(10)));
           expect(await ogNFT.ownerOf(0)).to.eq(await alice.getAddress());
@@ -404,7 +393,7 @@ describe("OGNFTOffering", () => {
           expect(metadata.endBlock).to.eq(0);
 
           // buy phase
-          await expect(ogOfferingAsAlice.buyNFT(0, signatureAsAlice)).to.revertedWith(
+          await expect(ogOfferingAsAlice.buyNFT(0)).to.revertedWith(
             "OGNFTOffering::withinBlockRange:: invalid block number"
           );
         });
@@ -419,7 +408,7 @@ describe("OGNFTOffering", () => {
         const stakingTokenAsAlice = SimpleToken__factory.connect(stakingTokens[0].address, alice);
         await stakingTokens[0].mint(await alice.getAddress(), value);
         await stakingTokenAsAlice.approve(ogOffering.address, value);
-        await ogOfferingAsAlice.buyNFT(0, signatureAsAlice);
+        await ogOfferingAsAlice.buyNFT(0);
         expect(await stakingTokens[0].balanceOf(await dev.getAddress())).to.eq(value.div(10));
         expect(await stakingTokens[0].balanceOf(seller)).to.eq(value.sub(value.div(10)));
         expect(await ogNFT.ownerOf(0)).to.eq(await alice.getAddress());


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE  -->
## Description
This is a fix pr for changing a modifier from using `permit` to `notEOA` 
## Purpose of this change
some hardware wallet doesn't support a message signing mechanism
## Is this PR Breaking Changes?
- [x] Y
- [ ] N
## Changes:
- update deployment params
- add a script for setting a new delay for timelock
- add script for changing a delay in a timelock contract
- change from permit signature to not eoa to avoid signing failure using a ledger
- add a contract for upgrading a booster using a timelock