### PR TITLE
[FEAT] Add A Script For Set A Buy Limit Count In ogNFTOffering Using A Timelock

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "script:mainnet:ogNftOffering:validate:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/validate/deploy_og_nft_offering.ts",
     "script:mainnet:ogNftOffering:validate:001": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/validate/ready_to_sell.ts",
     "script:mainnet:ogNftOffering:timelock:000": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/timelock/upgrade.ts",
+    "script:mainnet:ogNftOffering:timelock:001": "hardhat --network mainnet run --no-compile ./scripts/og-nft-offering/timelock/timelock_set_buy_limit_count.ts",
     
     "script:mainnet:periphery:T000": "hardhat --network mainnet run --no-compile ./scripts/periphery/fund_me_dummies.ts"
   },

--- a/scripts/og-nft-offering/timelock/timelock_set_buy_limit_count.ts
+++ b/scripts/og-nft-offering/timelock/timelock_set_buy_limit_count.ts
@@ -1,0 +1,42 @@
+import { FileService, TimelockService, ITimelockResponse, getConfig, withNetworkFile } from "../../../utils";
+
+async function main() {
+  /*
+  ░██╗░░░░░░░██╗░█████╗░██████╗░███╗░░██╗██╗███╗░░██╗░██████╗░
+  ░██║░░██╗░░██║██╔══██╗██╔══██╗████╗░██║██║████╗░██║██╔════╝░
+  ░╚██╗████╗██╔╝███████║██████╔╝██╔██╗██║██║██╔██╗██║██║░░██╗░
+  ░░████╔═████║░██╔══██║██╔══██╗██║╚████║██║██║╚████║██║░░╚██╗
+  ░░╚██╔╝░╚██╔╝░██║░░██║██║░░██║██║░╚███║██║██║░╚███║╚██████╔╝
+  ░░░╚═╝░░░╚═╝░░╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚══╝╚═╝╚═╝░░╚══╝░╚═════╝░
+  Check all variables below before execute the deployment script
+  */
+
+  const NEW_BUY_LIMIT_COUNT = 30;
+  const EXACT_ETA = "";
+
+  const config = getConfig();
+  const timelockTransactions: Array<ITimelockResponse> = [];
+
+  console.log(`>> Queue Transaction to set a buy limit count to ${NEW_BUY_LIMIT_COUNT} through Timelock`);
+  timelockTransactions.push(
+    await TimelockService.queueTransaction(
+      `set buy limit count of ${config.OGNFTOffering} to ${NEW_BUY_LIMIT_COUNT}`,
+      config.OGNFTOffering,
+      "0",
+      "setBuyLimitCount(uint256)",
+      ["uint256"],
+      [NEW_BUY_LIMIT_COUNT],
+      EXACT_ETA
+    )
+  );
+  console.log("✅ Done");
+
+  await FileService.write("set-buy-limit-count", timelockTransactions);
+}
+
+withNetworkFile(main)
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE  -->
## Description
This is a pr for adding a script for setting a buy limit count in og nft offering using a timelock
## Is this PR Breaking Changes?
- [ ] Y
- [x] N
## Changes:
- add a script for set a buy limit count in ogNFTOffering using a timelock